### PR TITLE
Made underlying DexFile of BasicMultiDexFile accessible

### DIFF
--- a/src/main/java/lanchon/multidexlib2/BasicMultiDexFile.java
+++ b/src/main/java/lanchon/multidexlib2/BasicMultiDexFile.java
@@ -50,4 +50,8 @@ public class BasicMultiDexFile<T extends MultiDexContainer<? extends MultiDexFil
 		return container;
 	}
 
+	public DexFile getUnderlyingDexFile() {
+		return dexFile;
+	}
+
 }


### PR DESCRIPTION
Hi,

I am a maintainer of the Soot - Java optimization framework. We are interested in using multidexlib2 for parsing and writing out Android Apks consisting of multiple dex files.

In our implementation, we need access the `DexBackedDexFile` class, to acquire the there mentioned type information.
Correct me if I am wrong, but s far as I can see, there is no possibility to access the underlying `DexBackedDexFile` from the`BasicMultiDexFile` class.

This merge request virtually just adds a getter to the `BasicMultiDexFile` class, to make the underlying Dexfile accessible.

Best,
Manuel