### PR TITLE
Update to dexlib2 2.5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
     id 'signing'
 }
 
-def dexlib2Version = '2.3.4'
+def dexlib2Version = '2.5.2'
 def multidexlib2VersionSuffix = '.r2'
 
 group = 'com.github.lanchon.dexpatcher'
@@ -23,7 +23,7 @@ version = dexlib2Version + multidexlib2VersionSuffix
 ext.mainArtifact = 'multidexlib2'
 ext.artifactName = mainArtifact
 
-sourceCompatibility = '1.7'
+sourceCompatibility = '1.8'
 def jdk = findProperty('JDK7_HOME') as String ?: '/usr/lib/jvm/java-7-openjdk-amd64'
 def jdk_rt = new File(jdk, 'jre/lib/rt.jar')
 if (jdk_rt.exists()) compileJava.options.bootstrapClasspath = files(jdk_rt)
@@ -34,6 +34,7 @@ repositories {
 
 dependencies {
     api 'org.smali:dexlib2:' + dexlib2Version
+    api 'com.google.guava:guava:31.1-jre'
 }
 
 apply from: 'configure-artifacts.gradle'


### PR DESCRIPTION
Updated dexlib2 to version 2.5.2.
Updated source compatibility to 1.8.
Included necessary guava runtime dependency.
